### PR TITLE
feat: Phase 8 - Expanded CLI Template Discovery & Advanced Docs

### DIFF
--- a/Classes/Command/GenerateStorybookManifestCommand.php
+++ b/Classes/Command/GenerateStorybookManifestCommand.php
@@ -4,18 +4,36 @@ declare(strict_types=1);
 namespace MyVendor\MyFluidStorybook\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
 class GenerateStorybookManifestCommand extends Command
 {
-    // Extension key to scan. For this basic implementation, it's hardcoded.
-    private const TARGET_EXTENSION_KEY = 'my_fluid_storybook';
+    private const OPTION_EXTENSION_KEYS = 'extension-keys';
+    private const SELF_EXTENSION_KEY = 'my_fluid_storybook'; // Key of this extension
+
+    // System/core extensions to exclude from 'scan all' mode
+    private const SYSTEM_EXTENSION_PREFIXES = [
+        'core', 'sys_', 'be_', 'fe_', 'extbase', 'fluid', 'install', 'recordlist',
+        'info', 'scheduler', 'impexp', 'lowlevel', 'reports', 'setup', 'workspaces',
+        'version', 'backend', 'frontend', 'documentation', 'tstemplate', 'filelist',
+        'about', 'extensionmanager', 't3editor', 'adminpanel', 'belog', 'beuser',
+        'felogin', 'form', 'linkvalidator', 'redirects', 'seo', 'sys_note',
+        'typo3db_legacy', 'viewpage', 'webpagetitle_tsफेvider', // common system/global extensions
+    ];
+    private const EXCLUDE_EXACT_KEYS = [ // Exact keys to exclude
+        self::SELF_EXTENSION_KEY, // Exclude this extension itself from "scan all"
+        'typo3_console', // The console itself
+        // Add other specific keys if needed
+    ];
+
 
     public function __construct(
         private readonly PackageManager $packageManager
@@ -25,7 +43,16 @@ class GenerateStorybookManifestCommand extends Command
 
     protected function configure(): void
     {
-        $this->setHelp('Scans the "' . self::TARGET_EXTENSION_KEY . '" extension for Fluid templates, partials, and layouts and generates a JSON manifest file in Resources/Public/Storybook/template-manifest.json');
+        $this->setHelp(
+            'Scans specified TYPO3 extensions (or all active non-system extensions by default) ' .
+            'for Fluid templates, partials, and layouts, then generates a JSON manifest file ' .
+            'in ' . self::SELF_EXTENSION_KEY . '/Resources/Public/Storybook/template-manifest.json'
+        );
+        $this->addArgument(
+            self::OPTION_EXTENSION_KEYS,
+            InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+            'Space-separated list of extension keys to scan (e.g., my_sitepackage my_other_ext). If omitted, scans all active non-system extensions.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -33,12 +60,28 @@ class GenerateStorybookManifestCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Generating Storybook Fluid Template Manifest');
 
-        if (!$this->packageManager->isPackageActive(self::TARGET_EXTENSION_KEY)) {
-            $io->error('The target extension "' . self::TARGET_EXTENSION_KEY . '" is not active. Manifest generation aborted.');
-            return Command::FAILURE;
-        }
+        $extensionKeysToScan = $input->getArgument(self::OPTION_EXTENSION_KEYS);
+        $specificExtensionsProvided = !empty($extensionKeysToScan);
 
-        $packagePath = $this->packageManager->getPackage(self::TARGET_EXTENSION_KEY)->getPackagePath();
+        if (!$specificExtensionsProvided) {
+            $io->writeln('No specific extension keys provided. Scanning all active non-system extensions...');
+            $allActivePackages = $this->packageManager->getActivePackages();
+            $extensionKeysToScan = [];
+            foreach ($allActivePackages as $package) {
+                $extKey = $package->getPackageKey();
+                if ($this->shouldScanExtension($extKey)) {
+                    $extensionKeysToScan[] = $extKey;
+                } else {
+                    $io->writeln(sprintf('Skipping system/excluded extension: %s', $extKey), OutputInterface::VERBOSITY_VERBOSE);
+                }
+            }
+            if (empty($extensionKeysToScan)) {
+                $io->warning('No suitable extensions found to scan in "scan all" mode.');
+                // Still proceed to write an empty manifest
+            }
+        } else {
+            $io->writeln('Scanning specified extensions: ' . implode(', ', $extensionKeysToScan));
+        }
 
         $manifest = [
             'templates' => [],
@@ -46,37 +89,56 @@ class GenerateStorybookManifestCommand extends Command
             'layouts' => [],
         ];
 
-        $scanPaths = [
+        $scanPathsDefinition = [
             'templates' => 'Resources/Private/Templates/',
             'partials' => 'Resources/Private/Partials/',
             'layouts' => 'Resources/Private/Layouts/',
         ];
 
-        foreach ($scanPaths as $type => $relativePath) {
-            $fullDirectoryPath = PathUtility::sanitizeTrailingSeparator($packagePath) . $relativePath;
-            if (!is_dir($fullDirectoryPath)) {
-                $io->writeln(sprintf('Directory for %s not found: %s (Skipping)', $type, $fullDirectoryPath));
+        foreach ($extensionKeysToScan as $extKey) {
+            if (!$this->packageManager->isPackageActive($extKey)) {
+                $io->warning(sprintf('Specified extension "%s" is not active or does not exist. Skipping.', $extKey));
                 continue;
             }
+            $io->section(sprintf('Scanning extension: %s', $extKey));
+            $package = $this->packageManager->getPackage($extKey);
+            $packagePath = $package->getPackagePath();
 
-            $files = GeneralUtility::getFilesInDir($fullDirectoryPath, 'html', true); // Get .html files, full path
+            foreach ($scanPathsDefinition as $typeKey => $relativePath) {
+                $fullDirectoryPath = PathUtility::sanitizeTrailingSeparator($packagePath) . $relativePath;
+                if (!is_dir($fullDirectoryPath)) {
+                    $io->writeln(sprintf('Directory for %s not found: %s (Skipping)', $typeKey, $fullDirectoryPath), OutputInterface::VERBOSITY_VERBOSE);
+                    continue;
+                }
 
-            foreach ($files as $filePath) {
-                $fileName = basename($filePath);
-                $fileNameWithoutExtension = pathinfo($fileName, PATHINFO_FILENAME);
-                $extPath = 'EXT:' . self::TARGET_EXTENSION_KEY . '/' . $relativePath . $fileName;
+                $files = GeneralUtility::getFilesInDir($fullDirectoryPath, 'html', true);
 
-                $manifest[$type][] = [
-                    'path' => $extPath,
-                    'type' => ucfirst($type), // Template, Partial, Layout
-                    'extension' => self::TARGET_EXTENSION_KEY,
-                    'name' => $fileNameWithoutExtension,
-                ];
-                $io->writeln(sprintf('Found %s: %s', ucfirst($type), $extPath));
+                foreach ($files as $filePath) {
+                    $fileName = basename($filePath);
+                    $fileNameWithoutExtension = pathinfo($fileName, PATHINFO_FILENAME);
+                    // Ensure relative path within Resources/Private/... is used for EXT: path
+                    $extSpecificPath = $relativePath . $fileName;
+                    $extPath = 'EXT:' . $extKey . '/' . $extSpecificPath;
+
+                    $manifest[$typeKey][] = [
+                        'path' => $extPath,
+                        'type' => ucfirst($typeKey),
+                        'extension' => $extKey,
+                        'name' => $fileNameWithoutExtension,
+                    ];
+                    $io->writeln(sprintf('Found %s: %s', ucfirst($typeKey), $extPath), OutputInterface::VERBOSITY_VERY_VERBOSE);
+                }
             }
         }
 
-        $manifestPath = PathUtility::sanitizeTrailingSeparator($packagePath) . 'Resources/Public/Storybook/template-manifest.json';
+        // Determine path to THIS extension (my_fluid_storybook) to save the manifest
+        $thisExtensionPackage = $this->packageManager->getPackage(self::SELF_EXTENSION_KEY);
+        if (!$thisExtensionPackage) {
+             $io->error('Could not locate the main "' . self::SELF_EXTENSION_KEY . '" package to save the manifest. This should not happen.');
+             return Command::FAILURE;
+        }
+        $thisExtensionPath = $thisExtensionPackage->getPackagePath();
+        $manifestPath = PathUtility::sanitizeTrailingSeparator($thisExtensionPath) . 'Resources/Public/Storybook/template-manifest.json';
         $manifestDir = dirname($manifestPath);
 
         if (!is_dir($manifestDir)) {
@@ -86,10 +148,24 @@ class GenerateStorybookManifestCommand extends Command
         $jsonContent = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         if (GeneralUtility::writeFile($manifestPath, $jsonContent)) {
             $io->success('Successfully generated template manifest: ' . $manifestPath);
+            $io->writeln(sprintf('Found %d templates, %d partials, %d layouts.', count($manifest['templates']), count($manifest['partials']), count($manifest['layouts'])));
             return Command::SUCCESS;
         } else {
             $io->error('Failed to write template manifest to: ' . $manifestPath);
             return Command::FAILURE;
         }
+    }
+
+    private function shouldScanExtension(string $extKey): bool
+    {
+        if (in_array($extKey, self::EXCLUDE_EXACT_KEYS, true)) {
+            return false;
+        }
+        foreach (self::SYSTEM_EXTENSION_PREFIXES as $prefix) {
+            if (str_starts_with($extKey, $prefix)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/Documentation/AdvancedRecipes.md
+++ b/Documentation/AdvancedRecipes.md
@@ -1,0 +1,262 @@
+# Advanced Recipes & Practical Guides
+
+This document provides practical recipes and guides for leveraging the features of the `my_fluid_storybook` integration to achieve common development tasks.
+
+## Recipe 1: Story for a `tt_content` Element with Live TYPO3 Data
+
+This recipe shows how to create a Storybook story that fetches data for a specific `tt_content` element from your TYPO3 database and renders it using its Fluid template.
+
+**Prerequisites:**
+- The Dynamic Data API endpoint must be enabled and working (see `Documentation/DynamicData.md`).
+- You have a Fluid template suitable for rendering the `tt_content` type you want to preview (e.g., `CeTextMedia.html`).
+- You know the UID of the `tt_content` element you want to fetch.
+
+**Steps:**
+
+1.  **Ensure `fetchTypo3Record` is available to your stories:**
+    As configured in `preview.js`, `fetchTypo3Record` should be available on `window.fetchTypo3Record`.
+
+2.  **Create your story file (e.g., `MyTextMedia.stories.js`):**
+    ```javascript
+    // MyTextMedia.stories.js
+    // Assuming fetchTypo3Record and FluidTemplate are globally available (e.g., on window)
+
+    export default {
+      title: 'TYPO3 Content Elements/TextMedia (Live Data)',
+      tags: ['autodocs'],
+      argTypes: {
+        contentElementUid: { control: 'number', name: 'Content Element UID' },
+        // You might add more argTypes here if the template needs other variables not from the record
+      },
+    };
+
+    const Template = (args, { loaded }) => {
+      const container = document.createElement('div');
+
+      if (loaded && loaded.fetchError) {
+        container.innerHTML = `<p style="color:red;">Error fetching data: ${loaded.fetchError}</p>`;
+        return container;
+      }
+      if (!loaded || !loaded.contentElementData) {
+        container.innerHTML = args.contentElementUid > 0 ? '<p>Loading content element data...</p>' : '<p>Enter a UID to load data.</p>';
+        return container;
+      }
+
+      window.FluidTemplate({
+        templatePath: 'EXT:my_sitepackage/Resources/Private/Templates/ContentElements/TextMedia.html', // Adjust to your CE template path
+        variables: {
+          // Pass the entire record, or specific fields as needed by your template
+          data: loaded.contentElementData, // TYPO3 CE templates often expect data in {data.field_name}
+          // or record: loaded.contentElementData, // if your template uses {record.field_name}
+        }
+      })
+      .then(html => { container.innerHTML = html; })
+      .catch(renderError => {
+        container.innerHTML = `<p style="color:red;">Render error: ${renderError.message}</p>`;
+      });
+
+      return container;
+    };
+
+    export const LiveTextMedia = Template.bind({});
+    LiveTextMedia.args = {
+      contentElementUid: 1, // Replace with a valid UID from your TYPO3 tt_content table
+    };
+
+    LiveTextMedia.loaders = [
+      async (context) => {
+        const uid = context.args.contentElementUid;
+        if (!uid || uid <= 0) {
+          return { contentElementData: null };
+        }
+        try {
+          const record = await window.fetchTypo3Record('tt_content', uid);
+          return { contentElementData: record };
+        } catch (error) {
+          console.error("Failed to load tt_content record:", error);
+          return { fetchError: error.message || 'Unknown error' };
+        }
+      },
+    ];
+    ```
+
+3.  **Adapt your Fluid template (`TextMedia.html`):**
+    Ensure your template expects variables in the way you pass them (e.g., `{data.header}`, `{data.bodytext}`).
+
+---
+
+## Recipe 2: Making Fluid Components Themeable in Storybook
+
+Leverage the basic theming setup (see `Documentation/Theming.md`) to make your components switch between light/dark (or other) themes.
+
+**Prerequisites:**
+- Theming (CSS custom properties + Storybook toolbar) is configured as per `Documentation/Theming.md`.
+
+**Steps:**
+
+1.  **Design your Fluid template's CSS with CSS Custom Properties:**
+    ```css
+    /* In your extension's main CSS file */
+    :root { /* Light theme (default) */
+      --my-component-bg: #ffffff;
+      --my-component-text: #333333;
+      --my-component-border: 1px solid #cccccc;
+    }
+
+    [data-theme="dark"] { /* Dark theme overrides */
+      --my-component-bg: #2a2a2a;
+      --my-component-text: #eeeeee;
+      --my-component-border: 1px solid #555555;
+    }
+
+    .my-custom-themable-component {
+      background-color: var(--my-component-bg);
+      color: var(--my-component-text);
+      border: var(--my-component-border);
+      padding: 1rem;
+      transition: background-color 0.3s, color 0.3s;
+    }
+    ```
+
+2.  **Use the class in your Fluid template:**
+    ```html
+    <!-- EXT:my_sitepackage/Resources/Private/Templates/MyThemableComponent.html -->
+    <div class="my-custom-themable-component">
+        <h3>{headline}</h3>
+        <p>This component's styles adapt to the selected theme.</p>
+    </div>
+    ```
+
+3.  **Create a story for it:**
+    The story itself doesn't need special theme arguments if the theme switcher is global.
+    ```javascript
+    // MyThemableComponent.stories.js
+    export default {
+      title: 'Components/My Themable Component',
+      argTypes: { headline: { control: 'text'} }
+    };
+    // ... (Standard Template rendering logic) ...
+    export const Default = Template.bind({});
+    Default.args = {
+      templatePath: 'EXT:my_sitepackage/Resources/Private/Templates/MyThemableComponent.html',
+      headline: 'I change with themes!'
+    };
+    ```
+    Now, using the theme switcher in the Storybook toolbar will change the `data-theme` attribute on `document.documentElement`, and your component's CSS will adapt.
+
+---
+
+## Recipe 3: Logging Interactions with Storybook Actions
+
+Capture DOM events from your rendered Fluid template and log them in the Storybook Actions panel.
+
+**Prerequisites:**
+- `@storybook/addon-actions` is available (part of `@storybook/addon-essentials`).
+
+**Steps:**
+
+1.  **Identify interactive elements in your Fluid template:**
+    Give them a unique ID or class.
+    ```html
+    <!-- EXT:my_sitepackage/Resources/Private/Templates/InteractiveCard.html -->
+    <div class="interactive-card">
+        <h4>{title}</h4>
+        <button type="button" id="card-learn-more-{uniqueId}">Learn More</button>
+    </div>
+    ```
+
+2.  **Define actions in your story's `argTypes`:**
+    ```javascript
+    // InteractiveCard.stories.js
+    export default {
+      title: 'Components/Interactive Card',
+      argTypes: {
+        title: { control: 'text' },
+        uniqueId: { control: 'text', defaultValue: '1' }, // To make button ID unique if multiple cards
+        onLearnMoreClick: { action: 'learnMoreClicked', description: 'Card Learn More button clicked' }
+      }
+    };
+    ```
+
+3.  **Attach event listeners in the story's render logic:**
+    ```javascript
+    const Template = (args) => {
+      const container = document.createElement('div');
+      // ... (FluidTemplate call) ...
+      window.FluidTemplate({ /* ... */ })
+        .then(html => {
+          container.innerHTML = html;
+          const buttonId = `card-learn-more-${args.uniqueId}`;
+          const button = container.querySelector(`#${buttonId}`);
+          if (button) {
+            button.addEventListener('click', (event) => {
+              args.onLearnMoreClick({ cardTitle: args.title, buttonId });
+            });
+          }
+        })
+        // ... (catch errors) ...
+      return container;
+    };
+    // ... (bind story) ...
+    ```
+    When the "Learn More" button is clicked, the `onLearnMoreClick` action (provided by Storybook via `argTypes`) is called, and the event + payload appears in the Actions panel.
+
+---
+
+## Recipe 4: Using the 'Manifest Driven Story'
+
+Quickly preview any template listed in your `template-manifest.json`.
+
+**Prerequisites:**
+- You have run `./vendor/bin/typo3 storybook:generate-manifest` in your TYPO3 project.
+- Storybook has been restarted or refreshed since the manifest was generated/updated.
+
+**Steps:**
+
+1.  **Navigate to the story**: Find the "TYPO3 Fluid > Manifest Driven Story" in your Storybook sidebar.
+2.  **Select a template**: Use the "Select Template (from Manifest)" dropdown. This lists templates found by the CLI command.
+3.  **Provide variables**: Use the "Variables" JSON object control to input any data the selected template might need (e.g., `{"headline": "My Test", "bodytext": "<p>Content here.</p>"}`).
+4.  **Observe**: The story will attempt to render the chosen template with the variables you provided.
+
+**Tips:**
+- If the template list is empty or outdated, re-run the CLI command and refresh Storybook.
+- The `variables` control is generic. You'll need to know what variables your selected template expects.
+
+---
+
+## Recipe 5: Debugging Common Rendering Issues
+
+Troubleshooting tips when your Fluid template doesn't render as expected in Storybook.
+
+1.  **Check Storybook Error Display**:
+    -   The area where the component renders often shows a red box with error details from `FluidTemplate.ts` (e.g., `APIError`, `NetworkError`). Note the `type`, `status`, and `details`.
+
+2.  **Browser Developer Console**:
+    -   Open your browser's dev tools (usually F12).
+    -   **Console Tab**: Look for detailed JavaScript errors from `FluidTemplate.ts` or other Storybook processes.
+    -   **Network Tab**:
+        -   Filter for requests to `/api/fluid/render` (or your data API endpoint).
+        -   Check the request URL, parameters (templatePath, variables).
+        -   Inspect the Response:
+            -   If status is 404 (Not Found): Double-check `templatePath`.
+            -   If status is 500 (Server Error): The response body (if JSON) might contain the PHP error message from TYPO3.
+            -   If status is 400 (Bad Request): Problem with `templatePath` format or `variables` JSON.
+            -   If status is 403 (Forbidden): API disabled (e.g. Data API not in Dev context).
+        -   Check `X-FluidStorybook-Cache` header to see if response was cached.
+
+3.  **TYPO3 Server Logs**:
+    -   Check `var/log/` in your TYPO3 project for detailed PHP errors if the API returns a 500 error. This is often the most informative for Fluid rendering issues (e.g., ViewHelper errors, syntax errors in Fluid).
+
+4.  **Simplify**:
+    -   **Template**: Reduce your Fluid template to the simplest possible version to isolate the problematic part.
+    -   **Variables**: Start with an empty `variables: {}` object in your story, then add variables back one by one.
+    -   **ViewHelpers**: If you suspect a ViewHelper, try removing it or replacing it with static content temporarily.
+
+5.  **Verify `templatePath`**:
+    -   Ensure it's exactly `EXT:extension_key/Resources/Private/Templates/MyTemplate.html` (or Partials/Layouts). Case sensitivity matters on some systems.
+
+6.  **Test API Directly**:
+    -   Construct the API URL (e.g., `http://your-site.ddev.site/api/fluid/render?templatePath=EXT:my_ext/...&variables={...}`) and try opening it directly in your browser or using a tool like Postman/curl to see the raw response. Remember to URL-encode parameters.
+
+---
+*(More recipes can be added as new features or common patterns emerge.)*

--- a/Documentation/AutomatedDocumentationDeployment.md
+++ b/Documentation/AutomatedDocumentationDeployment.md
@@ -1,0 +1,108 @@
+# Automated Documentation Deployment Strategy
+
+This document outlines a conceptual strategy for automatically building and deploying the project documentation for `my_fluid_storybook`. The documentation primarily consists of the main `README.md` and various Markdown files within the `Documentation/` directory.
+
+## Goals
+
+-   Make documentation easily accessible online.
+-   Ensure documentation is always up-to-date with the main branch.
+-   Automate the publishing process.
+
+## Options Considered
+
+### 1. GitHub Pages directly from Markdown files
+-   **Method**: Configure GitHub Pages to serve content directly from the `main` branch, either from the root or a `/docs` subfolder.
+-   **Pros**:
+    -   Extremely simple to set up; often just a few clicks in repository settings.
+    -   No additional build tools or dependencies needed.
+    -   Markdown files are rendered using GitHub's default styling, which is clean and readable.
+-   **Cons**:
+    -   Limited customization of theme and layout.
+    -   Navigation might be basic (relying on manual links between pages).
+    -   No advanced features like full-text search without third-party solutions.
+
+### 2. Static Site Generator (SSG) with GitHub Pages
+-   **Method**: Use an SSG (e.g., MkDocs, Docsify, Docusaurus, VitePress) to build an HTML site from the Markdown files. Deploy the generated static HTML site to GitHub Pages.
+-   **Tools Examples**:
+    -   **MkDocs**: Python-based, simple, good for project documentation, themeable. Uses a `mkdocs.yml` for configuration.
+    -   **Docsify**: JavaScript-based, renders Markdown on the fly (no build step to HTML, just serves the `index.html` and JS). Very easy to get started.
+    -   **Docusaurus/VitePress**: More powerful, React/Vue-based, offer more features like versioning, i18n, blogging, but also have a higher learning curve and more dependencies.
+-   **Pros**:
+    -   Professional look and feel with themes.
+    -   Better navigation (auto-generated sidebars, table of contents).
+    -   Full-text search capabilities (often built-in or via plugins).
+    -   More control over layout and presentation.
+-   **Cons**:
+    -   Adds a build step to the CI/CD pipeline.
+    -   Introduces new dependencies (Python or Node.js based, depending on the tool).
+    -   Slightly more complex initial setup.
+
+## Recommended Approach
+
+A phased approach is recommended:
+
+**Phase A: Simple GitHub Pages (Immediate)**
+1.  **Consolidate Documentation**: Ensure all primary documentation files (`README.md` and files from `Documentation/`) are well-organized, potentially moving them into a `/docs` directory at the project root if GitHub Pages is configured to serve from there. (Alternatively, GitHub Pages can serve from the root of `main`).
+2.  **Enable GitHub Pages**: In the repository settings, enable GitHub Pages to build from the `main` branch (and the chosen folder, e.g., `/docs` or `/` (root)).
+3.  **Navigation**: Manually ensure links between documentation pages are correct and relative. Create a main landing page if using a `/docs` folder (e.g., `docs/index.md` could be a copy of or link to the main `README.md`).
+
+**Phase B: Static Site Generator (Future Enhancement, if needed)**
+1.  **Evaluate Need**: If the documentation becomes extensive and requires better navigation, search, or theming, then transition to an SSG.
+2.  **Choose SSG**:
+    -   For simplicity and good Markdown support, **MkDocs** (with a theme like `mkdocs-material`) or **Docsify** are excellent starting points. Docsify is particularly easy as it often doesn't require a separate build step for the HTML content itself.
+3.  **Setup SSG**:
+    -   Add SSG configuration files (e.g., `mkdocs.yml` for MkDocs, or an `index.html` and configuration for Docsify).
+    -   Structure Markdown files as required by the SSG.
+4.  **Update CI/CD Pipeline**: Add a job to the GitHub Actions workflow to:
+    -   Install the SSG tool and its dependencies.
+    -   Run the SSG build command (e.g., `mkdocs build` for MkDocs).
+    -   Deploy the generated static site (e.g., from `site/` directory for MkDocs) to a `gh-pages` branch using an action like `peaceiris/actions-gh-pages`.
+
+## Conceptual GitHub Actions Workflow for SSG (e.g., MkDocs - Phase B)
+
+```yaml
+# .github/workflows/deploy-docs.yml (Conceptual)
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main # Or your primary branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs and theme
+        run: |
+          pip install mkdocs mkdocs-material # Example dependencies
+
+      - name: Build documentation
+        run: mkdocs build # Generates static site in 'site' directory
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          # publish_branch: gh-pages # Optional: specify branch
+          # user_name: 'github-actions[bot]' # Optional
+          # user_email: 'github-actions[bot]@users.noreply.github.com' # Optional
+```
+
+## Initial Focus
+
+For the immediate future, **Phase A (Simple GitHub Pages directly from Markdown)** is recommended due to its simplicity. This provides immediate online access to the documentation with minimal overhead. The transition to an SSG (Phase B) can be considered later as the project and its documentation evolve.
+
+To implement Phase A:
+- No CI/CD changes are strictly necessary if GitHub Pages is set to build from `main` directly. The existing CI (`ci.yml`) already handles code quality.
+- The main task is to ensure the Markdown files are well-linked and organized, possibly within a `/docs` folder if preferred for GitHub Pages configuration. For this project, keeping `Documentation/*` and `README.md` at the root and configuring GitHub Pages to serve from the root of the `main` branch might be the easiest start.
+```

--- a/README.md
+++ b/README.md
@@ -323,7 +323,15 @@ You can generate or update the manifest by running the following command from yo
 
 The command will output the path to the generated `template-manifest.json` file, which is located at:
 `packages/my_fluid_storybook/Resources/Public/Storybook/template-manifest.json`
-(Adjust path if your extension is installed in a different location like `typo3conf/ext/`).
+(Adjust path if your `my_fluid_storybook` extension is installed in a different location).
+
+### Command Behavior
+
+-   **Without arguments**: Scans all currently active TYPO3 extensions. It attempts to filter out common system and core extensions (e.g., `core`, `backend`, `fluid`, `extbase`, etc.) and the `my_fluid_storybook` extension itself. The goal is to discover templates in your site packages or custom component extensions.
+-   **With `extension-keys` argument(s)**: Scans only the specified extension(s). Multiple extension keys can be provided, separated by spaces.
+    Example: `./vendor/bin/typo3 storybook:generate-manifest my_site_package my_components_ext`
+
+The output `template-manifest.json` will aggregate findings from all successfully scanned extensions. The `extension` property within each manifest entry indicates its source extension.
 
 ### Output File Example (`template-manifest.json`)
 
@@ -361,6 +369,7 @@ The command will output the path to the generated `template-manifest.json` file,
 *(The content of the JSON above is illustrative and will reflect the actual files found in the `my_fluid_storybook` extension when the command is run.)*
 
 This command currently only scans the `my_fluid_storybook` extension itself. Future enhancements may allow scanning of other extensions.
+The above description reflects the enhanced command. The previous example output is illustrative of a single-extension scan. With multiple extensions, the list would contain entries from all of them.
 
 ### Using the Manifest in Stories (Example)
 

--- a/Resources/Public/Storybook/.storybook/preview.js
+++ b/Resources/Public/Storybook/.storybook/preview.js
@@ -1,3 +1,4 @@
+// Resources/Public/Storybook/.storybook/preview.js
 import { FluidTemplate } from '../../JavaScript/FluidTemplate.ts';
 import { fetchTypo3Record } from '../../JavaScript/Typo3Data.ts';
 


### PR DESCRIPTION
This commit enhances the CLI command for template discovery to support scanning multiple or all relevant extensions, and adds new documentation for automated documentation deployment concepts and advanced usage recipes.

Key changes in this phase:

1.  **Technical Improvement - Expanded CLI Template Discovery:**
    *   Modified `GenerateStorybookManifestCommand.php` (`storybook:generate-manifest`):
        *   Added an optional `extension-keys` argument to specify which
          extensions to scan.
        *   If no argument is provided, the command now scans all active
          non-system/core TYPO3 extensions by default, applying a filter
          to exclude irrelevant ones.
        *   The `template-manifest.json` now aggregates findings from all
          scanned extensions.
    *   Updated `README.md` to reflect the new CLI command capabilities.

2.  **Community/Maintenance - Documentation Deployment (Conceptual):**
    *   Created `Documentation/AutomatedDocumentationDeployment.md` which
        outlines strategies and tools (e.g., GitHub Pages, Static Site
        Generators) for future automated deployment of project documentation.

3.  **Community/Maintenance - "Advanced Recipes" Documentation:**
    *   Created `Documentation/AdvancedRecipes.md`.
    *   This new file provides practical step-by-step guides for you on
        topics such as:
        *   Creating stories with live TYPO3 data.
        *   Implementing themeable Fluid components in Storybook.
        *   Logging interactions using Storybook Actions.
        *   Utilizing the "Manifest Driven Story".
        *   Debugging common rendering issues.

These improvements make the template discovery more versatile and provide you with richer documentation for both understanding project direction and practical application of its features.